### PR TITLE
Add fallback for og:type metadata

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -40,6 +40,8 @@
 {% if page.date %}
   <meta property="og:type" content="article" />
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
+{% else %}
+  <meta property="og:type" content="website" />
 {% endif %}
 
 {% if paginator.previous_page %}
@@ -48,7 +50,6 @@
 {% if paginator.next_page %}
   <link rel="next" href="{{ paginator.next_page_path | absolute_url }}" />
 {% endif %}
-
 
 {% if seo_tag.image %}
   <meta name="twitter:card" content="{{ page.twitter.card | default: site.metadata.twitter.card | default: "summary_large_image" }}" />

--- a/spec/bridgetown_seo_tag_integration_spec.rb
+++ b/spec/bridgetown_seo_tag_integration_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe Bridgetown::SeoTag do
     end
   end
 
+  context "with page.date" do
+    let(:page) { make_page("date" => Date.new) }
+    it 'outputs open graph type article' do
+      expected = %r!<meta property="og:type" content="article" />!
+      expect(output).to match(expected)
+    end
+  end
+
+  context "without page.date" do
+    let(:page) { make_page("date" => nil) }
+    it 'outputs open graph type website' do
+      expected = %r!<meta property="og:type" content="website" />!
+      expect(output).to match(expected)
+    end
+  end
+
   context "with page.description" do
     let(:page) { make_page("description" => "foo") }
 


### PR DESCRIPTION
Porting the changes from https://github.com/jekyll/jekyll-seo-tag/pull/391.

Closes #3 