### PR TITLE
Update README.md frontmatter defaults link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 
 ### Setting a default image
 
-You can define a default image using [Front Matter defaults](https://www.bridgetownrb.com/docs/configuration/front-matter-defaults/) to provide a default Twitter Card or Open Graph image to all of your documents.
+You can define a default image using [Front Matter defaults](https://www.bridgetownrb.com/docs/content/front-matter-defaults/) to provide a default Twitter Card or Open Graph image to all of your documents.
 
 Here is a very basic example, that you are encouraged to adapt to your needs:
 


### PR DESCRIPTION
Frontmatter defaults link now points to the correct location in bridgetown repo: https://www.bridgetownrb.com/docs/content/front-matter-defaults/

Closes https://github.com/bridgetownrb/bridgetown-seo-tag/issues/8

Thanks, Jared for the pointer.