### PR TITLE
Remove page number in title

### DIFF
--- a/lib/bridgetown-seo-tag/drop.rb
+++ b/lib/bridgetown-seo-tag/drop.rb
@@ -71,8 +71,6 @@ module Bridgetown
                      page_title || site_title
                    end
 
-        return page_number + @title if page_number
-
         @title
       end
 
@@ -187,16 +185,6 @@ module Bridgetown
 
       def homepage_or_about?
         page["url"] =~ HOMEPAGE_OR_ABOUT_REGEX
-      end
-
-      def page_number
-        return unless @context["paginator"] && @context["paginator"]["page"]
-
-        current = @context["paginator"]["page"]
-        total = @context["paginator"]["total_pages"]
-        paginator_message = site["seo_paginator_message"] || "Page %<current>s of %<total>s for "
-
-        format(paginator_message, current: current, total: total) if current > 1
       end
 
       attr_reader :context

--- a/spec/bridgetown_seo_tag/drop_spec.rb
+++ b/spec/bridgetown_seo_tag/drop_spec.rb
@@ -501,24 +501,4 @@ RSpec.describe Bridgetown::SeoTag::Drop do
     end
   end
 
-  context "pagination" do
-    let(:context) do
-      make_context(
-        { page: page, site: site },
-        "paginator" => { "page" => 2, "total_pages" => 10 }
-      )
-    end
-
-    it "render default pagination title" do
-      expect(subject.send(:page_number)).to eq("Page 2 of 10 for ")
-    end
-
-    context "render custom pagination title" do
-      let(:site_config) { { "seo_paginator_message" => "%<current>s of %<total>s" } }
-
-      it "renders the correct page number" do
-        expect(subject.send(:page_number)).to eq("2 of 10")
-      end
-    end
-  end
 end


### PR DESCRIPTION
This is not needed and breaks the built in pagination title handling.

This also requires you remove [this section](https://github.com/bridgetownrb/bridgetown-seo-tag/wiki/Advanced-Usage#customizing-title-modifier-for-paginated-pages) from the wiki.