### PR TITLE
Add Mastodon/Fediverse attribution meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bridgetown SEO Tag adds the following meta tags to your site:
 * Canonical URL
 * Next and previous URLs on paginated pages
 * [Open Graph](https://ogp.me/) title, description, site title, and URL (for Facebook, LinkedIn, etc.)
+* Mastodon [verification](https://docs.joinmastodon.org/user/profile/#verification) and [attribution](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/)
 * [Twitter Summary Card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started) metadata
 
 While you could theoretically add the necessary metadata tags yourself, Bridgetown SEO Tag provides a battle-tested template of crowdsourced best-practices.
@@ -74,6 +75,10 @@ The SEO tag will respect any of the following if included in your site's `site_m
 * `tagline` - A short description (e.g., A blog dedicated to reviewing cat gifs), used in instances (like a home page) where there isn't a dedicated document title.
 * `description` - A longer description used for the description meta tag. Also used as fallback for documents that don't provide their own `description` and as part of the home page title tag if `tagline` is not defined.
 * `author` - global author information (see [Advanced usage](https://github.com/bridgetownrb/bridgetown-seo-tag/wiki/Advanced-Usage#author-information))
+
+* `mastodon` - You can add a single Mastodon handle to both verify your Mastodon profile, and link to your Mastodon profile when someone shares your content on the network.
+  * `mastodon:server` - The server for your account (mastodon.social, for instance)
+  * `mastodon:username` - Your username (with or without `@`)
 
 * `twitter` - You can add a single Twitter handle to be used in Twitter card tags, like "bridgetownrb". Or you use a YAML mapping with additional details:
   * `twitter:card` - The site's default card type

--- a/lib/bridgetown-seo-tag/author_drop.rb
+++ b/lib/bridgetown-seo-tag/author_drop.rb
@@ -55,7 +55,7 @@ module Bridgetown
         @resolved_author = sources.find { |s| !s.to_s.empty? }
       end
 
-      # If resolved_author is a string, attempts to find coresponding author
+      # If resolved_author is a string, attempts to find corresponding author
       # metadata in `site.data.authors`
       #
       # Returns a hash representing additional metadata or an empty hash

--- a/lib/bridgetown-seo-tag/drop.rb
+++ b/lib/bridgetown-seo-tag/drop.rb
@@ -100,7 +100,7 @@ module Bridgetown
       end
 
       # Returns a Drop representing the page's image
-      # Returns nil if the image has no path, to preserve backwards compatability
+      # Returns nil if the image has no path, to preserve backwards compatibility
       def image
         @image ||= ImageDrop.new(page: page, context: @context)
         @image if @image.path

--- a/lib/bridgetown-seo-tag/image_drop.rb
+++ b/lib/bridgetown-seo-tag/image_drop.rb
@@ -24,7 +24,7 @@ module Bridgetown
         @context = context
       end
 
-      # Called path for backwards compatability, this is really
+      # Called path for backwards compatibility, this is really
       # the escaped, absolute URL representing the page's image
       # Returns nil if no image path can be determined
       def path

--- a/lib/bridgetown-seo-tag/url_helper.rb
+++ b/lib/bridgetown-seo-tag/url_helper.rb
@@ -9,7 +9,7 @@ module Bridgetown
       # Determines if the given string is an absolute URL
       #
       # Returns true if an absolute URL.
-      # Retruns false if it's a relative URL
+      # Returns false if it's a relative URL
       # Returns nil if it is not a string or can't be parsed as a URL
       def absolute_url?(string)
         return false unless string

--- a/lib/template.html
+++ b/lib/template.html
@@ -69,6 +69,11 @@
   <meta property="twitter:title" content="{{ seo_tag.page_title }}" />
 {% endif %}
 
+{% if site.metadata.mastodon %}
+  <meta name="fediverse:creator" content="@{{ site.metadata.mastodon.username | remove:'@' }}@{{ site.metadata.mastodon.server | remove:'https://' }}" />
+  <link rel="me" href="https://{{ site.metadata.mastodon.server | remove:'https://' }}/@{{ site.metadata.mastodon.username | remove:'@' }}" />
+{% endif %}
+
 {% if site.metadata.twitter %}
   <meta name="twitter:site" content="@{{ site.metadata.twitter.username | default: site.metadata.twitter | remove:'@' }}" />
 

--- a/spec/bridgetown_seo_tag/author_drop_spec.rb
+++ b/spec/bridgetown_seo_tag/author_drop_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Bridgetown::SeoTag::AuthorDrop do
     context "without an author name or handle" do
       let(:page_meta) { { "author" => { "foo" => "bar" } } }
 
-      it "dosen't blow up" do
+      it "doesn't blow up" do
         expect(subject["twitter"]).to be_nil
       end
     end


### PR DESCRIPTION
Add `<link rel="me">` and `fediverse:creator` meta.

See https://joinmastodon.org/verification and https://github.com/mastodon/mastodon/pull/30398

To use, open `site.metadata.yml` and add mastodon username and server:
```yml
mastodon:
  username: handle
  server: mastodon.server
```
Generates: 
```html
<link rel="me" href="https://mastodon.server/@handle">
<meta name="fediverse:creator" content="@handle@mastodon.server">
```