### PR TITLE
Allow og:type to be set via seo.og_type front matter

### DIFF
--- a/lib/bridgetown-seo-tag/drop.rb
+++ b/lib/bridgetown-seo-tag/drop.rb
@@ -123,6 +123,10 @@ module Bridgetown
         @date_published ||= filters.date_to_xmlschema(page["date"]) if page["date"]
       end
 
+      def og_type
+        @og_type ||= page_seo["og_type"] || (post? ? "article" : "website")
+      end
+
       def type
         @type ||= if page_seo["type"]
                     page_seo["type"]
@@ -185,6 +189,11 @@ module Bridgetown
 
       def homepage_or_about?
         page["url"] =~ HOMEPAGE_OR_ABOUT_REGEX
+      end
+
+      def post?
+        raw_page = @context.registers[:page]
+        raw_page.respond_to?(:collection) && raw_page.collection&.label == "posts"
       end
 
       attr_reader :context

--- a/lib/template.html
+++ b/lib/template.html
@@ -40,11 +40,9 @@
   {% endif %}
 {% endif %}
 
-{% if page.date %}
-  <meta property="og:type" content="article" />
+<meta property="og:type" content="{{ seo_tag.og_type }}" />
+{% if seo_tag.og_type == "article" and page.date %}
   <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}" />
-{% else %}
-  <meta property="og:type" content="website" />
 {% endif %}
 
 {% if paginator.previous_page %}

--- a/spec/bridgetown_seo_tag_integration_spec.rb
+++ b/spec/bridgetown_seo_tag_integration_spec.rb
@@ -137,10 +137,10 @@ RSpec.describe Bridgetown::SeoTag do
     end
   end
 
-  context "with page.date" do
+  context "with page.date but not a post" do
     let(:page) { make_page("date" => Date.new) }
-    it "outputs open graph type article" do
-      expected = %r!<meta property="og:type" content="article" />!
+    it "outputs open graph type website" do
+      expected = %r!<meta property="og:type" content="website" />!
       expect(output).to match(expected)
     end
   end
@@ -149,6 +149,26 @@ RSpec.describe Bridgetown::SeoTag do
     let(:page) { make_page("date" => nil) }
     it "outputs open graph type website" do
       expected = %r!<meta property="og:type" content="website" />!
+      expect(output).to match(expected)
+    end
+  end
+
+  context "with seo.og_type set in front matter" do
+    let(:page) { make_page("date" => Date.new, "seo" => { "og_type" => "article" }) }
+    it "uses the og_type from front matter" do
+      expected = %r!<meta property="og:type" content="article" />!
+      expect(output).to match(expected)
+    end
+
+    it "outputs article:published_time when og_type is article" do
+      expect(output).to match(%r!article:published_time!)
+    end
+  end
+
+  context "with seo.og_type set to a custom type" do
+    let(:page) { make_page("seo" => { "og_type" => "product" }) }
+    it "uses the custom og_type" do
+      expected = %r!<meta property="og:type" content="product" />!
       expect(output).to match(expected)
     end
   end
@@ -319,7 +339,7 @@ RSpec.describe Bridgetown::SeoTag do
       let(:page) { make_post(meta) }
       let(:context) { make_context(page: page, site: site) }
 
-      it "outputs post meta" do
+      it "defaults to og:type article for posts" do
         expected = %r!<meta property="og:type" content="article" />!
         expect(output).to match(expected)
       end


### PR DESCRIPTION
Fixes #6. All pages in Bridgetown have a date property, so og:type was always "article". Users can now override it with seo.og_type in front matter, falling back to the existing date-based logic.